### PR TITLE
Add xacro files of GNSS

### DIFF
--- a/urdf/sensors/gnss.gazebo.xacro
+++ b/urdf/sensors/gnss.gazebo.xacro
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+
+  <xacro:macro name="gnss_sensor_gazebo" params="prefix parent">
+    <gazebo reference="${prefix}_link">
+      <sensor name="${prefix}_sensor" type="gps">
+        <always_on>true</always_on>
+        <update_rate>10</update_rate>
+        <gps>
+          <position_sensing>
+            <horizontal>
+              <noise type="gaussian">
+                <mean>0.0</mean>
+                <stddev>2e-4</stddev>
+              </noise>
+            </horizontal>
+            <vertical>
+              <noise type="gaussian">
+                <mean>0.0</mean>
+                <stddev>2e-4</stddev>
+              </noise>
+            </vertical>
+          </position_sensing>
+        </gps>
+        <plugin name="${prefix}_controller" filename="libgazebo_ros_gps_sensor.so">
+          <ros>
+            <namespace>/gnss</namespace>
+            <remapping>~/out:=fix</remapping>
+          </ros>
+        </plugin>
+      </sensor>
+    </gazebo>
+  </xacro:macro>
+</robot>

--- a/urdf/sensors/gnss.urdf.xacro
+++ b/urdf/sensors/gnss.urdf.xacro
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<robot name="raspicat_gnss_sensor" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find raspicat_description)/urdf/sensors/gnss.gazebo.xacro"/>
+
+  <xacro:macro name="gnss_sensor" params="prefix parent *joint_origin">
+    <joint name="${prefix}_joint" type="fixed">
+      <xacro:insert_block name="joint_origin"/>
+      <parent link="${parent}"/>
+      <child link="${prefix}_link"/>
+    </joint>
+    <link name="${prefix}_link"/>
+  </xacro:macro>
+</robot>


### PR DESCRIPTION
変更前：GNSS関係のxacroがなく、display.launch.pyが起動しない
変更後：urdf/sensors/以下に、gnss.urdf.xacroとgnss.gazebo.xacroを追加。上記のlaunchが起動するのを確認